### PR TITLE
Add honorific_prefix field

### DIFF
--- a/lib/member_row.rb
+++ b/lib/member_row.rb
@@ -15,6 +15,10 @@ class MemberRow < Scraped::HTML
     name_parts.reject { |p| prefixes.include? p }.join(' ').tidy
   end
 
+  field :honorific_prefix do
+    name_parts.select { |p| wanted_prefixes.include? p }.map(&:tidy).join(';')
+  end
+
   field :area do
     noko[2].text.strip
   end

--- a/lib/member_row.rb
+++ b/lib/member_row.rb
@@ -12,7 +12,7 @@ class MemberRow < Scraped::HTML
   end
 
   field :name do
-    noko[1].text.strip.sub(/^Hon.? /, '')
+    name_parts.reject { |p| prefixes.include? p }.join(' ').tidy
   end
 
   field :area do
@@ -32,6 +32,22 @@ class MemberRow < Scraped::HTML
   end
 
   private
+
+  def wanted_prefixes
+    %w(Prof.)
+  end
+
+  def unwanted_prefixes
+    %w(Hon.)
+  end
+
+  def prefixes
+    wanted_prefixes + unwanted_prefixes
+  end
+
+  def name_parts
+    noko[1].text.tidy.split(' ')
+  end
 
   def link
     noko[1].css('a/@href').text

--- a/lib/member_row.rb
+++ b/lib/member_row.rb
@@ -38,11 +38,11 @@ class MemberRow < Scraped::HTML
   private
 
   def wanted_prefixes
-    %w(Prof.)
+    %w[Prof.]
   end
 
   def unwanted_prefixes
-    %w(Hon.)
+    %w[Hon.]
   end
 
   def prefixes

--- a/test/custom_test_data/member_row.yml
+++ b/test/custom_test_data/member_row.yml
@@ -2,6 +2,7 @@
   :id: '14'
   :photo: http://parliament.go.tz/polis/uploads/members/0.85403400%201485859515.png
   :name: Julius Kalanga Laizer
+  :honorific_prefix: ''
   :area: Monduli
   :party: CHADEMA
   :member_type: Constituent Member

--- a/test/member_data_test.rb
+++ b/test/member_data_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative './test_helper'
 require_relative '../lib/members_page.rb'
 

--- a/test/member_data_test.rb
+++ b/test/member_data_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require_relative './test_helper'
+require_relative '../lib/members_page.rb'
+
+describe 'member data' do
+  url = 'http://www.parliament.go.tz/mps-list'
+  around { |test| VCR.use_cassette(url.split('/').last, &test) }
+
+  subject do
+    MembersPage.new(response: Scraped::Request.new(url: url).response)
+               .member_rows
+               .find { |row| row.id == id }
+  end
+
+  describe 'Member with Prof prefix' do
+    let(:id) { '568' }
+    it 'should return the expected data' do
+      subject.to_h.must_equal(
+        id:               '568',
+        photo:            'http://www.parliament.go.tz/site/images/img.jpg',
+        name:             'Palamagamba John Aidan Mwaluko Kabudi',
+        honorific_prefix: 'Prof.',
+        area:             'Nominated',
+        party:            'CCM',
+        member_type:      'Nominated',
+        source:           'http://www.parliament.go.tz/administrations/568'
+      )
+    end
+  end
+
+  describe 'Member with Dr prefix' do
+    let(:id) { '401' }
+    # Note: Current live data includes names with Dr prefix attached
+    it 'should return the expected data' do
+      subject.to_h.must_equal(
+        id:               '401',
+        photo:            'http://parliament.go.tz/polis/uploads/members/0.76488000%201486015693.png',
+        name:             'Dr. Tulia Ackson',
+        honorific_prefix: '',
+        area:             'Nominated',
+        party:            'CCM',
+        member_type:      'Nominated',
+        source:           'http://www.parliament.go.tz/administrations/401'
+      )
+    end
+  end
+
+  describe 'Member without honorific prefix' do
+    let(:id) { '458' }
+    it 'should return the expected data' do
+      subject.to_h.must_equal(
+        id:               '458',
+        photo:            'http://parliament.go.tz/polis/uploads/members/0.57945900%201485964592.png',
+        name:             'Abbas Ali Mwinyi',
+        honorific_prefix: '',
+        area:             'Fuoni',
+        party:            'CCM',
+        member_type:      'Constituent Member',
+        source:           'http://www.parliament.go.tz/administrations/458'
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is a step towards fixing: https://github.com/everypolitician/everypolitician-data/issues/25705

A member is incoming with Prof. attached to their name. This PR adds an honorific prefix field.

This PR only knows of one title: 'Prof'. There a multiple members in the live data with 'Dr.' attached to their names. A future PR will add Dr. to the list of prefixes. (Fixes: https://github.com/everypolitician-scrapers/tanzania-parliament/issues/2)

~**Note**: There is no test associated with this change as I cannot find a straightforward way to test it. The data is captured from a MemberRow, and the members list is paginated.~