### PR TITLE
Replace space in URL with %20 instead of using URI.encode

### DIFF
--- a/lib/member_row.rb
+++ b/lib/member_row.rb
@@ -7,7 +7,7 @@ class MemberRow < Scraped::HTML
   end
 
   field :photo do
-    URI.encode(noko[0].css('img/@src').text)
+    noko[0].css('img/@src').text.gsub(' ', '%20')
   end
 
   field :name do


### PR DESCRIPTION
This is a necessary step towards adding the :honorific_prefix field: https://github.com/everypolitician-scrapers/tanzania-parliament/pull/3 (Part of: everypolitician/everypolitician-data#25705)

`URI.encode` has been obsoleted. Since it was used here to handle the whitespace, it has been substituted with a gsub.

Note: I am unable to find a direct equivalent in the standard library. `CGI.escape` and `URI.encode_www_form_component` do not return the same value.

```ruby
str = "https://example url.com"

URI.encode str
=> "https://example%20url.com"

CGI.escape str
=> "https%3A%2F%2Fexample+url.com"

URI.encode_www_form_component str
=> "https%3A%2F%2Fexample+url.com"
```