### PR TITLE
Silence warning message: replace obsoleted URI.encode

### DIFF
--- a/lib/member_row.rb
+++ b/lib/member_row.rb
@@ -7,7 +7,7 @@ class MemberRow < Scraped::HTML
   end
 
   field :photo do
-    URI.encode(noko[0].css('img/@src').text)
+    noko[0].css('img/@src').text.gsub(' ', '%20')
   end
 
   field :name do

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'scraped'
+require_relative 'member_row'
 
 class MembersPage < Scraped::HTML
   field :member_rows do

--- a/test/cassettes/mps-list.yml
+++ b/test/cassettes/mps-list.yml
@@ -1,0 +1,3821 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.parliament.go.tz/mps-list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Feb 2017 14:29:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Cache-Control:
+      - no-cache
+      Set-Cookie:
+      - XSRF-TOKEN=eyJpdiI6ImVXNDdSWjFCcmd5SzN4UVwvMVZ3M2pRPT0iLCJ2YWx1ZSI6ImRJejZpY1FibFVCbE9IM2tEZjJLVmdtdlRiVXdERkdcL0V2TnJ0dlo1XC9wcGlSZ2hnN0V3SjE5dmU5Nkc0MHV4MWVVdXNlM3ZNYWc5MGU5N2x5TFVlZlE9PSIsIm1hYyI6IjlmZGE0ZGY3ZTNhMWU4ZmI5NDI3MWY5YmVhNzliYTcwZmM1ODBjODY0YzQwOTMyYTViYmEyNWQyNzBhNjNmODEifQ%3D%3D;
+        expires=Mon, 20-Feb-2017 16:29:20 GMT; Max-Age=7200; path=/
+      - laravel_session=eyJpdiI6IlFYcEgzYURodTVTTG9pYzRvMWNYaGc9PSIsInZhbHVlIjoiM3dcL3g4aGpSRDVrNXBPUzVqQVZTdkFxaWh4MFB5anZaT1JNY1dhNmNkclJxWUQ1Yyt2UUh2NDlPdlh2bng5Kzl0UW9TM3VaR1FWWkdBNEw4b2gyYm5BPT0iLCJtYWMiOiIxZjgxODMxNzAwYWJmM2U1ZTNhNWFkYTBmMjY0ZDMwOTEzY2Q2ZjdjOTVhOGIzZDkzYWRkYzVjYzdhMTNhMjE4In0%3D;
+        expires=Mon, 20-Feb-2017 16:29:20 GMT; Max-Age=7200; path=/; httponly
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: " <!DOCTYPE html>\n<!-- Website template by freewebsitetemplates.com
+        -->\n<html>\n<head>\n\t<meta http-equiv=\"Content-Type\" content=\"text/html;
+        charset=utf-8\" />\n\t<meta name=\"csrf-token\" content=\"0OKZHNYaYynMFnJhtvHXbuGdVnUQKAAAwivwHOuI\">\n\t<title>Parliament
+        of Tanzania</title>\n\n\t<link rel=\"stylesheet\" href=\"http://www.parliament.go.tz/site/css/jquery-ui.css\"
+        type=\"text/css\" charset=\"utf-8\" />\n\t<link rel=\"stylesheet\" href=\"http://www.parliament.go.tz/site/css/bootstrap.min.css\"
+        type=\"text/css\" charset=\"utf-8\" />\n\t<link rel=\"stylesheet\" href=\"http://www.parliament.go.tz/site/css/dataTables.bootstrap.css\">\n\t<link
+        rel=\"stylesheet\" href=\"http://www.parliament.go.tz/site/css/style.css\"
+        type=\"text/css\" charset=\"utf-8\" />\n\t<link rel=\"stylesheet\" href=\"http://www.parliament.go.tz/site/font-awesome/css/font-awesome.min.css\">\n\n\t<link
+        rel=\"stylesheet\" href=\"http://www.parliament.go.tz/site/css/token-input.css\"
+        >\n\n\t<script src=\"http://www.parliament.go.tz/site/js/jquery.js\" type=\"text/javascript\"></script>\n\t<script
+        src=\"http://www.parliament.go.tz/site/js/jquery.dataTables.min.js\" type=\"text/javascript\"></script>\n\t<script
+        src=\"http://www.parliament.go.tz/site/js/dataTables.bootstrap.min.js\" type=\"text/javascript\"></script>\n\t<script
+        src=\"http://www.parliament.go.tz/site/js/bootstrap.js\" type=\"text/javascript\"></script>\n\t<script
+        type=\"text/javascript\">\n\t\t$(document).ready(function() {\n\t\t    $('#example').DataTable({\n\t\t
+        \   \t\"ordering\": false\n\t\t    });\n\n\t\t});\n    </script>\n\n\t<script
+        src=\"http://www.parliament.go.tz/site/js/js-image-slider.js\" type=\"text/javascript\"></script>\n\t<script
+        src=\"http://www.parliament.go.tz/site/js/prefixfree.min.js\" type=\"text/javascript\"></script>\n\n\t<script
+        src=\"http://www.parliament.go.tz/site/js/token-input.js\" type=\"text/javascript\"></script>\n\t\n\t<!--
+        By Dickson -->\n\t<script src=\"http://www.parliament.go.tz/site/js/custom.js\"
+        type=\"text/javascript\"></script>\n\t\n \t<script type=\"text/javascript\">\n
+        \       $(document).ready(function() {            \n            var timer;
+        \                             \n            $(\"#slideshow > div:gt(0)\").hide();
+        \           \n            $(\"#slideshow\")\n                .mouseenter(function()
+        {\n                    if (timer) { clearInterval(timer) }\n                })\n
+        \               .mouseleave(function() {\n                    timer = setInterval(function()
+        {\n                        $(\"#slideshow > div:first\")\n                            .fadeOut(2000)\n
+        \                           .next()\n                            .fadeIn(2000)\n
+        \                           .end()\n                            .appendTo(\"#slideshow\");\n
+        \                   }, 20000);\n                })\n                .mouseleave();
+        \                                 \n        });\n\n    </script>\n\n\t<!--[if
+        lte IE 7]>\n\t\t<link rel=\"stylesheet\" href=\"css/ie.css\" type=\"text/css\"
+        charset=\"utf-8\" />\t\n\t<![endif]-->\n</head>\n\n<body>\n\n\t<div class=\"top_nav\">\n\t\t<div
+        class=\"nav_wrap\">\n\n\t\t\t<form method=\"GET\" action=\"http://www.parliament.go.tz/mps-list\"
+        accept-charset=\"UTF-8\" class=\"search\">\n\n\t\t\t\t<input class=\"keyw\"
+        type=\"search\" size=\"25\" name=\"q\" value=\"\" placeholder=\"Search\">\n\t\t\t\t<button
+        type=\"submit\">Search</button>\n\n\t\t\t</form>\n\n\t\t\t<nav class=\"site-navigation\">\t\t\n\t\t\t\t<ul
+        class=\"menu\">\n\t\t\t\t\t<li><a href=\"http://www.parliament.go.tz/contact\">Contact
+        Us</a></li>\n\t\t\t\t\t<li><a href=\"http://www.parliament.go.tz/tender-list\">Tenders</a></li>\n\t\t\t\t\t<li><a
+        href=\"http://www.parliament.go.tz/vacancy-list\">Vacancy</a></li>\n\t\t\t\t\t<li><a
+        href=\"http://www.parliament.go.tz/glossary-list\">Glossary</a></li>\n\t\t\t\t\t<li><a
+        href=\"http://www.parliament.go.tz/galleries\">Photo Gallery</a></li>\n\t\t\t\t\t<!--
+        <li><a href=\"http://parliament.go.tz/polis/registrations/create\">MP</a></li>
+        -->\n\t\t\t\t\t\t                  <li><a href=\"http://www.parliament.go.tz/language/sw\">Kiswahili</a></li>\n\t
+        \               \t\t\t\t\t\n\t\t\t\t\t\n\t\t\t\t</ul>\n\t\t\t</nav>\t\t\n\t\t</div>\n\t</div>\n\t<div
+        class=\"header\">\n\t\t<div class=\"gov_logo\"></div>\n\t\t<div class=\"org_logo\"></div>\n\t\t<div
+        class=\"org_name\">\n\t\t\t<p id=\"head\">United Republic of Tanzania</p>\n\t\t\t<p
+        id=\"main\">Parliament of Tanzania</p>\n\t\t\t<!-- <p id=\"last\">Good Roads
+        for National Development</p> -->\n\t\t</div>\n\t</div>\n\t<div class=\"menu_wrap\">\n\t\t<ul
+        class=\"menuTemplate1 decor1_1\" license=\"trlicense\">\n\t\t\t<li><a href=\"http://www.parliament.go.tz\">Home</a></li>\n\t\t\t<li><a
+        href='#'>About Us <i class='fa fa-caret-down left'></i></a><div class='drop
+        decor1_2'><div class='left'><div><a href= http://www.parliament.go.tz/pages/mandate>
+        <i class='fa fa-angle-double-right right'></i> Mandate</a><br><a href= http://www.parliament.go.tz/pages/functions>
+        <i class='fa fa-angle-double-right right'></i> Functions</a><br><a href= http://www.parliament.go.tz/pages/vision-and-mission>
+        <i class='fa fa-angle-double-right right'></i> Vision and Mission</a><br><a
+        href= http://www.parliament.go.tz/pages/structure> <i class='fa fa-angle-double-right
+        right'></i> Structure</a><br><a href= http://www.parliament.go.tz/pages/office-of-the-clerk>
+        <i class='fa fa-angle-double-right right'></i> Office of the Clerk</a><br><a
+        href= http://www.parliament.go.tz/pages/administration> <i class='fa fa-angle-double-right
+        right'></i> Administration</a><br><a href= http://www.parliament.go.tz/pages/history>
+        <i class='fa fa-angle-double-right right'></i> History</a><br><a href= http://www.parliament.go.tz/pages/compositon>
+        <i class='fa fa-angle-double-right right'></i> Compositon</a><br></div></div><div
+        style='clear: both;'></div></div></li><li><a href='#'>Parliamentary Business
+        <i class='fa fa-caret-down left'></i></a><div class='drop decor1_2'><div class='left'><div><a
+        href= http://www.parliament.go.tz/acts-list> <i class='fa fa-angle-double-right
+        right'></i> Acts</a><br><a href= http://www.parliament.go.tz/bills-list> <i
+        class='fa fa-angle-double-right right'></i> Bills</a><br><a href= http://www.parliament.go.tz/hansards-list>
+        <i class='fa fa-angle-double-right right'></i> Hansards</a><br><a href= http://www.parliament.go.tz/order-paper-list>
+        <i class='fa fa-angle-double-right right'></i> Order Papers</a><br><a href=
+        http://www.parliament.go.tz/resolutions-list> <i class='fa fa-angle-double-right
+        right'></i> Resolutions</a><br><a href= http://www.parliament.go.tz/proceeding-list>
+        <i class='fa fa-angle-double-right right'></i> Proceedings</a><br><a href=
+        http://www.parliament.go.tz/statements-list> <i class='fa fa-angle-double-right
+        right'></i> Minister's Statement</a><br><a href= http://www.parliament.go.tz/motion-list>
+        <i class='fa fa-angle-double-right right'></i> Member's Private Motion</a><br><a
+        href= http://www.parliament.go.tz/subsidiary-list> <i class='fa fa-angle-double-right
+        right'></i> Subsidiary Legislation</a><br></div></div><div style='clear: both;'></div></div></li><li><a
+        href='#'>Committee System <i class='fa fa-caret-down left'></i></a><div class='drop
+        decor1_2'><div class='left'><div><a href= http://www.parliament.go.tz/committee-types-list>
+        <i class='fa fa-angle-double-right right'></i> Committee Types</a><br><a href=
+        http://www.parliament.go.tz/committee-composition-list> <i class='fa fa-angle-double-right
+        right'></i> Committee Composition</a><br><a href= http://www.parliament.go.tz/committee-reports-list>
+        <i class='fa fa-angle-double-right right'></i> Committee Reports</a><br></div></div><div
+        style='clear: both;'></div></div></li><li><a href='#'>Members of Parliament
+        <i class='fa fa-caret-down left'></i></a><div class='drop decor1_2'><div class='left'><div><a
+        href= http://www.parliament.go.tz/leaders-list> <i class='fa fa-angle-double-right
+        right'></i> Leadership</a><br><a href= http://www.parliament.go.tz/mps-list>
+        <i class='fa fa-angle-double-right right'></i> List of Members A-Z</a><br><a
+        href= http://www.parliament.go.tz/pages/overview> <i class='fa fa-angle-double-right
+        right'></i> Overview</a><br><a href= #> <i class='fa fa-angle-double-right
+        right'></i> MP's Directory</a><br><a href= #> <i class='fa fa-angle-double-right
+        right'></i> A Collection of Statutes Relevant for Parliamentary Business</a><br></div></div><div
+        style='clear: both;'></div></div></li><li><a href='#'>Publications <i class='fa
+        fa-caret-down left'></i></a><div class='drop decor1_2'><div class='left'><div><a
+        href= http://www.parliament.go.tz/budget-list> <i class='fa fa-angle-double-right
+        right'></i> Budget</a><br><a href= http://www.parliament.go.tz/publication/facts>
+        <i class='fa fa-angle-double-right right'></i> Fact Sheets</a><br><a href=
+        http://www.parliament.go.tz/publication/journals> <i class='fa fa-angle-double-right
+        right'></i> Constitution</a><br><a href= http://www.parliament.go.tz/publication/reports>
+        <i class='fa fa-angle-double-right right'></i> Parliamentary Reports</a><br><a
+        href= http://www.parliament.go.tz/publication/research> <i class='fa fa-angle-double-right
+        right'></i> Research Papers</a><br><a href= http://www.parliament.go.tz/publication/orders>
+        <i class='fa fa-angle-double-right right'></i> Standing Orders</a><br><a href=
+        http://www.parliament.go.tz/publication/books> <i class='fa fa-angle-double-right
+        right'></i> Books</a><br></div></div><div style='clear: both;'></div></div></li><li><a
+        href='#'>Visiting & Tours <i class='fa fa-caret-down left'></i></a><div class='drop
+        decor1_2'><div class='left'><div><a href= http://www.parliament.go.tz/pages/procedures-to-visit-the-parliament>
+        <i class='fa fa-angle-double-right right'></i> Procedure to visit the Parliament</a><br><a
+        href= http://www.parliament.go.tz/pages/do-s-and-don-ts> <i class='fa fa-angle-double-right
+        right'></i> Do's and Don'ts</a><br><a href= http://www.parliament.go.tz/application-form>
+        <i class='fa fa-angle-double-right right'></i> Application Form</a><br><a
+        href= http://www.parliament.go.tz/remarks> <i class='fa fa-angle-double-right
+        right'></i> Visitors' Remarks</a><br></div></div><div style='clear: both;'></div></div></li>\n\n\t\t</ul>\t\t\n\t</div>\n<div
+        class=\"in_body\">\n\t<div class=\"in_left\">\n\n\t\t\t\n\t<div class=\"breadcrumbs\">\n\t\t<ul>\n\t\t\t<li
+        class=\"size\"><a href=\"http://www.parliament.go.tz\"><i class=\"fa fa-home\"></i></a></li>\n\t\t\t<li><a
+        href=\"#\">Member of the Parliament</a></li>\n\t\t\t<!-- <li class=\"lsize\"><i
+        class=\"fa fa-angle-right\"></i></li>\n\t\t\t<li><a href=\"#\">Mandate</a></li>
+        -->\n\t\t</ul>\t\n\t\t<div class=\"in_print\">\n\t\t\t<span><a href=\"#\"><i
+        class=\"fa fa-envelope-o right\"></i>Email to a friend</a></span>\n\t\t\t<span><a
+        href=\"javascript:PrintDiv(divToPrint);\"><i class=\"fa fa-print right\"></i>Print</a></span>\n\t\t</div>\t\t\t\t\t\n\t</div>\n\t<div
+        class=\"body_info\" id=\"divToPrint\">\n\t\t<h3><span>Member of the Parliament</span></h3>\n\t\t<table
+        id=\"example\" class=\"table table-striped table-bordered new\" cellspacing=\"0\"
+        width=\"100%\">\n\t\t    <thead>\n\t            <tr>\n\t                <th
+        width=\"3%\">Photo</th>\n\t                <th>Name</th>\n\t                <th>Constituent</th>\n\t
+        \               <th>Party</th>\n\t                <th>Member Type</th>\n\t
+        \           </tr>\n\t        </thead>\n\n\t\t    <tbody>\n\t\t    \t\t\t\t
+        \   \t<tr class=\"odd\">\n\t\t\t    \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t
+        \   \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.57945900
+        1485964592.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t    \t\t\t</td>\n\t\t\t
+        \   \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/458\">Hon.
+        Abbas Ali Mwinyi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tFuoni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.77957700 1485860538.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/16\">Hon.
+        Abdallah Ally Mtolea</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTemeke\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44930400 1485965103.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/281\">Hon.
+        Abdallah Dadi Chikota</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNanyamba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.70030900 1485965902.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/344\">Hon.
+        Abdallah Hamis Ulega</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMkuranga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.75960400 1485954683.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/464\">Hon.
+        Abdallah  Haji  Ali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKiwani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://www.parliament.go.tz/site/images/img.jpg\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/562\">Hon.
+        Abdallah Majurah Bulembo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.54203400 1485964861.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/254\">Hon.
+        Abdulaziz Mohamed Abood</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMorogoro Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91065200 1485965938.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/354\">Hon.
+        Aeshi Khalfan Hilaly</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSumbawanga Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.77216400 1486010863.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/211\">Hon.
+        Agnes Mathew Marwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.58022000 1485965043.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/256\">Hon.
+        Ahmed Mabukhut Shabiby</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tGairo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.66009600 1485966152.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/420\">Hon.
+        Ahmed Ally Salum</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSolwa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.29722500 1485954811.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/496\">Hon.
+        Ahmed Juma Ngwali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tWawi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.48888600 1486014272.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/188\">Hon.
+        Aida Joseph Khenani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.07898300 1485965073.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/289\">Hon.
+        Ajali Rashid Akibar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNewala Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.17525200 1485954376.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/91\">Hon.
+        Albert Ntabaliba Obama</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBuhigwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.00433400 1485929781.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/79\">Hon.
+        Alex Raphael Gashaza</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNgara\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.68953900 1485964768.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/460\">Hon.
+        Ali Hassan  Omar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tJang'ombe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.82259500 1485964541.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/478\">Hon.
+        Ali Salim Khamis</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMwanakwerekwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.51908400 1485966377.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/430\">Hon.
+        Allan Joseph Kiula</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIramba Mashariki\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.90342700 1485965915.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/351\">Hon.
+        Ally Seif Ungando</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKibiti\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.09976100 1485964556.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/473\">Hon.
+        Ally Abdulla  Ally Saleh</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMalindi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.23846300 1485965961.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/523\">Hon.
+        Ally Mohamed Keissy</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNkasi Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.96586700 1485966552.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/436\">Hon.
+        Almas Athuman Maige</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTabora Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.36787300 1485929811.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/80\">Hon.
+        Amb Dr. Diodorus Buberwa Kamala</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tNkenge\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.81304700 1485966650.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/512\">Hon.
+        Amb. Adadi Mohamed Rajabu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMuheza\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.62108000 1486011455.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/213\">Hon.
+        Amina Nassoro Makilagi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.85017700 1486011773.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/214\">Hon.
+        Amina Saleh Athuman Mollel</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.89042200 1486016013.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/552\">Hon.
+        Amina Iddi Mabrouk</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHouse of Representatives\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tMember from House of Representatives\n\t\t\t\t
+        \           \t\t\t\t    \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t
+        \   \t<tr class=\"odd\">\n\t\t\t    \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t
+        \   \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.85431400
+        1486012323.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t    \t\t\t</td>\n\t\t\t
+        \   \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/215\">Hon.
+        Anastazia James Wambura</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.15946600 1486014291.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/192\">Hon.
+        Anatropia Lwehikila Theonest</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.77984900 1485966263.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/422\">Hon.
+        Andrew John Chenge</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBariadi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.20611300 1486011493.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/216\">Hon.
+        Angelina Adam Malembeka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.80307300 1485965277.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/293\">Hon.
+        Angeline Sylvester Lubala Mabula</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tIlemela\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.05707100 1453646011.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/218\">Hon.
+        Angellah Jasmine Mbelwa Kairuki</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.90853300 1486014350.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/196\">Hon.
+        Anna Joram Gidarya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.36071400 1486011373.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/219\">Hon.
+        Anna Richard Lupembe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://www.parliament.go.tz/site/images/img.jpg\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/564\">Hon.
+        Anne Kilango Malecela</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.56818000 1485954418.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/107\">Hon.
+        Anthony Calist Komu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMoshi Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.86955000 1485861011.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/40\">Hon.
+        Antony Peter Mavunde</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tDodoma mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.95971400 1486011149.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/221\">Hon.
+        Asha Mshimba Jecha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.22883900 1486010898.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/533\">Hon.
+        Asha Abdullah Juma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.71896200 1485964358.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/232\">Hon.
+        Atupele Fredy Mwakibete</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBusokelo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.52084700 1485954296.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/100\">Hon.
+        Augustine Vuma Holle</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKasulu Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.57845200 1485861386.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/53\">Hon.
+        Augustino Manyanda Masele</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbogwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.17966800 1486011558.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/223\">Hon.
+        Aysharose Ndogholi Mattembe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.26697900 1486010929.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/275\">Hon.
+        Azza Hilal Hamad</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.67804200 1485860446.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/18\">Hon.
+        Azzan Mussa Zungu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIlala\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.86857400 1485930148.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/510\">Hon.
+        Bahati Ali Abeid</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMahonda\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.22142200 1486011921.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/277\">Hon.
+        Bernadeta Kasabago Mushashu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.85866100 1485954888.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/456\">Hon.
+        Bhagwanji  Maganlal Meisuria</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChwaka\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.53517700 1485955542.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/229\">Hon.
+        Boniphace Mwita Getere</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBunda\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.06656700 1485860589.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/534\">Hon.
+        Bonnah Moses Kaluwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSegerea\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.66358100 1486011969.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/278\">Hon.
+        Bupe Nelson Mwakang'ata</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.64800400 1485964641.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/472\">Hon.
+        CAN.RTD Ali Khamis Masoud</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMfenesini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.31698900 1485965167.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/287\">Hon.
+        Capt. (Mst). George Huruma Mkuchika</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tNewala Mjini\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.25001800 1486011403.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/279\">Hon.
+        Catherine Valentine Magige</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.68455600 1485965188.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/285\">Hon.
+        Cecil  David Mwambe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNdanda\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91897600 1486015182.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/205\">Hon.
+        Cecilia Daniel Paresso</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.62476600 1485929839.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/76\">Hon.
+        Charles John Mwijage</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMuleba Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.16629100 1485965253.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/302\">Hon.
+        Charles Muhangwa Kitwanga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMisungwi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.79042000 1486014311.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/207\">Hon.
+        Conchesta Leonce Rwamlaza</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.46943700 1485861406.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/52\">Hon.
+        Constantine John Kanyasu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tGeita Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.22069000 1485866833.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/65\">Hon.
+        Cosato David Chumi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMafinga Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.35557600 1485966052.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/409\">Hon.
+        Daimu Iddi Mpakate</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTunduru Kusini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.54168900 1485954359.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/93\">Hon.
+        Daniel Nicodemus Nsanzugwako</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKasulu Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.38336000 1485966418.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/437\">Hon.
+        Daniel Edward Mtuka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tManyoni Mashariki\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.49858600 1485964508.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/243\">Hon.
+        David Ernest Silinde</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMomba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.14878500 1485965524.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/327\">Hon.
+        Deo Kasenyenda Sanga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMakambako\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.83108200 1485965613.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/546\">Hon.
+        Deogratias Francis Ngalawa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLudewa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.14934400 1485965985.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/376\">Hon.
+        Desderius John Mipata</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNkasi Kusini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.94066900 1486014323.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/209\">Hon.
+        Devotha Methew Minja</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.08058600 1485861426.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/47\">Hon.
+        Doto  Mashaka  Biteko</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBukombe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.76488000 1486015693.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/401\">Hon.
+        Dr. Tulia Ackson</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.79604100 1453647032.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/530\">Hon.
+        Dr. Abdallah Saleh Possi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.30339100 1485929915.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/503\">Hon.
+        Dr. Ally Yusuf Suleiman</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMgogoni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.30658300 1485861033.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/32\">Hon.
+        Dr. Ashatu Kachwamba Kijaji</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKondoa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.28975800 1486015653.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/527\">Hon.
+        Dr. Augustine Philip Mahiga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.65876600 1485965351.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/295\">Hon.
+        Dr. Charles John Tizeba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBuchosa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02822500 1486011136.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/286\">Hon.
+        Dr. Christine Gabriel Ishengoma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.11095000 1485966501.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/438\">Hon.
+        Dr. Dalaly Peter Kafumu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIgunga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.47198300 1485954438.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/112\">Hon.
+        Dr. David  Mathayo David</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSame Magharibi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.84748600 1486014610.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/210\">Hon.
+        Dr. Elly Marko Macha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.74652300 1485860480.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/22\">Hon.
+        Dr. Faustine Engelbert Ndugulile</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tKigamboni\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45920600 1485954457.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/102\">Hon.
+        Dr. Godwin Oloyce Mollel</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSiha\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.06609900 1485964877.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/261\">Hon.
+        Dr. Haji Hussein  Mponda</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMalinyi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.66735200 1485966565.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/442\">Hon.
+        Dr. Hamisi Andrea Kigwangalla</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNzega Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.77072000 1485964381.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/236\">Hon.
+        Dr. Harrison George Mwakyembe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKyela\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.24160500 1485964746.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/468\">Hon.
+        Dr. Hussein Ali Mwinyi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKwahani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.41009200 1486014337.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/312\">Hon.
+        Dr. Immaculate Sware Semesi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.95361500 1486010954.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/283\">Hon.
+        Dr. Jasmine Tiisekwa Bunga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tVyuo Vikuu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.93880700 1485955421.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/139\">Hon.
+        Dr. Mary Michael Nagu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHanang'\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.95792600 1486012016.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/291\">Hon.
+        Dr. Mary Machuche Mwanjelwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbeya Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.28945500 1485861340.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/50\">Hon.
+        Dr. Medard Matogolo Kalemani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChato\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.10743000 1486015845.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/531\">Hon.
+        Dr. Philip Isdor Mpango</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.99696100 1485954237.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/83\">Hon.
+        Dr. Pudenciana Wilfred  Kikwembe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tKavuu\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.19078100 1485966252.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/424\">Hon.
+        Dr. Raphael Masunga Chegeni</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBusega\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.73043200 1485965833.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/329\">Hon.
+        Dr. Shukuru Jumanne Kawambwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBagamoyo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.01827700 1486011344.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/294\">Hon.
+        Dr. Susan Alphonce Kolimba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.71790500 1485965216.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/273\">Hon.
+        Dua  William Nkurua</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNanyumbu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.28956300 1485966722.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/490\">Hon.
+        Dunstan Luka Kitandula</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMkinga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.42753000 1485965565.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/323\">Hon.
+        Edward Franz Mwalongo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNjombe Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.51466300 1485860847.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/42\">Hon.
+        Edwin Mgante Sannda</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKondoa Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.42926600 1485966178.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/419\">Hon.
+        Elias John Kwandikwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUshetu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.26634500 1485966358.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/441\">Hon.
+        Elibariki Emmanuel Kingu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSingida Magharibi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.70192900 1485955434.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/141\">Hon.
+        Emmanuel Papian John</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKiteto\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.43165300 1485966579.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/444\">Hon.
+        Emmanuel Adamson Mwakasaka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTabora Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.51655000 1485954283.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/89\">Hon.
+        Eng. Atashasta Justus Nditiye</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMuhambwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.40114900 1485966082.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/406\">Hon.
+        Eng. Edwin Amandus Ngonyani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNamtumbo \n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.06516300 1485965552.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/324\">Hon.
+        Eng. Gerson Hosea Lwenge</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tWanging'ombe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.53678100 1485964677.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/231\">Hon.
+        Eng. Hamad Yussuf Masauni</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKikwajuni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45807400 1485954143.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/82\">Hon.
+        Eng. Isack Aloyce Kamwelwe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKatavi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.41082900 1485954529.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/115\">Hon.
+        Eng. James Fransis Mbatia</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tVunjo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tNCCR-Mageuzi\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.07529900 1485860865.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/38\">Hon.
+        Eng. Joel Makanyaga Mwaka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChilonwa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44755100 1485966096.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/389\">Hon.
+        Eng. Ramo Matala Makani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTunduru Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.96500700 1485966108.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/404\">Hon.
+        Eng. Stella Martin Manyanya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNyasa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.78918500 1485955514.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/225\">Hon.
+        Ester Amos Bulaya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBunda Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91702700 1486011416.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/296\">Hon.
+        Ester Alexander Mahawe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45873100 1486011760.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/298\">Hon.
+        Ester Michael Mmasi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.51752000 1485955603.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/204\">Hon.
+        Esther Nicholus Matiko</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTarime Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44755100 1486011696.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/300\">Hon.
+        Esther Lukago Midimu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.51892400 1485966191.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/416\">Hon.
+        Ezekiel Magolyo Maige</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMsalala\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44895500 1486733668.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/388\">Hon
+        Faida Mohammed Bakar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44679900 1486011053.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/390\">Hon.
+        Fakharia Shomar Khamis</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.09923400 1486012214.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/392\">Hon.
+        Fatma Hassan Toufiq</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91484300 1486010975.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/393\">Hon.
+        Felister Aloyce Bura</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.61846700 1485955239.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/183\">Hon.
+        Flatei Gregory Massay</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbulu Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44256500 1485964340.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/248\">Hon.
+        Frank George Mwakajoka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTunduma\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.07800700 1485954543.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/104\">Hon.
+        Freeman Aikaeli Mbowe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHai\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.41642400 1485861053.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/41\">Hon.
+        George Boniface Simbachawene</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKibakwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.28925500 1485860890.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/45\">Hon.
+        George Malima Lubeleje</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMpwapwa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.82624100 1486016104.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/539\">Hon.
+        George Mcheche Masaju</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNone\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\t-\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tAttorney General\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.52939100 1485859100.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/8\">Hon.
+        Gibson Blasius Meiseyeki</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tArumeru-Magharibi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.33892500 1486014367.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/303\">Hon.
+        Gimbi Dotto Masaba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.57609600 1485859023.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/541\">Hon.
+        Godbless Jonathan Lema</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tArusha Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.07472500 1485927723.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/59\">Hon.
+        Godfrey William Mgimwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKalenga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.13921600 1485964979.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/544\">Hon.
+        Goodluck Asaph Mlinga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUlanga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.01937000 1486014410.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/306\">Hon.
+        Grace Sindato Kiwelu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.65311800 1486015296.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/310\">Hon.
+        Grace Victor Tendega</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.89765000 1461164862.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/459\">Hon.
+        Hafidh Ali Tahir</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tDimani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.78708400 1485954904.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/471\">Hon.
+        Haji Ameir Haji</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMakunduchi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.55623000 1485929935.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/475\">Hon.
+        Haji Khatib Kai</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMicheweni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02863100 1485860499.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/31\">Hon.
+        Halima James Mdee</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKawe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.30343700 1486015444.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/363\">Hon.
+        Halima Ali Mohammed</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45947500 1486010795.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/394\">Hon.
+        Halima Abdallah Bulembo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.70430300 1486628465.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/467\">Hon.
+        Hamadi Salim  Maalim</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKojani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.81022300 1486011099.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/386\">Hon.
+        Hamida Mohamedi Abdallah</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.40884700 1485954987.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/127\">Hon.
+        Hamidu Hassan Bobali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMchinga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.94290800 1485965799.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/346\">Hon.
+        Hamoud Abuu Jumaa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKibaha Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.78032100 1485964466.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/238\">Hon.
+        Haroon Mulla Pirmohamed</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbarali\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.82796200 1485954329.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/96\">Hon.
+        Hasna Sudi Katunda Mwilima</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKigoma Kusini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.66641500 1485955013.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/119\">Hon.
+        Hassan Selemani Kaunje</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLindi Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.05775300 1485955116.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/131\">Hon.
+        Hassan Elias Masala</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNachingwea\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.28619200 1485964607.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/462\">Hon.
+        Hassanali Mohamedali Ibrahim</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKiembesamaki\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.37171400 1485965135.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/272\">Hon.
+        Hawa Abdulrahiman Ghasia</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMtwara Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.72369900 1486011007.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/395\">Hon.
+        Hawa Mchafu Chakoma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.56829500 1486014842.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/536\">Hon.
+        Hawa Subira Mwaifunga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.49554100 1485861373.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/54\">Hon.
+        Hussein Nassor Amar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNyang'hwale\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.76650700 1485966489.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/447\">Hon.
+        Hussein Mohamed Bashe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNzega Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.75760400 1486016044.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/554\">Hon.
+        Hussein Ibrahim Makungu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHouse of Representatives\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tMember from House of Representatives\n\t\t\t\t
+        \           \t\t\t\t    \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t
+        \   \t<tr class=\"odd\">\n\t\t\t    \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t
+        \   \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.51636100
+        1485965973.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t    \t\t\t</td>\n\t\t\t
+        \   \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/364\">Hon.
+        Ignas Aloyce  Malocha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKwela\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44232000 1485929736.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/72\">Hon.
+        Innocent Lugha Bashungwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKaragwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.34794200 1485929764.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/74\">Hon.
+        Innocent Sebba Bilakwate</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKyerwa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.28500700 1485860575.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/25\">Hon.
+        Issa Ali Abbas Mangungu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbagala\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.77762500 1485955203.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/179\">Hon.
+        Issaay Zacharia Paulo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbulu Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.76648800 1486011866.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/116\">Hon.
+        Jacqueline Kandidus Ngonyani (Msongozi)</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.72967900 1485954928.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/482\">Hon.
+        Jaffar Sanya Jussa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tPaje\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.72953700 1486016028.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/556\">Hon.
+        Jaku Hashim Ayoub</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHouse of Representatives\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tMember from House of Representatives\n\t\t\t\t
+        \           \t\t\t\t    \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t
+        \   \t<tr class=\"odd\">\n\t\t\t    \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t
+        \   \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.79765100
+        1485964623.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t    \t\t\t</td>\n\t\t\t
+        \   \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/470\">Hon.
+        Jamal Kassim Ali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMagomeni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.57326000 1485955253.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/187\">Hon.
+        James Kinyasi Millya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSimanjiro\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.85755900 1485964259.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/234\">Hon.
+        Janet Zebedayo Mbene</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIleje\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.00054900 1485966735.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/484\">Hon.
+        January Yusuf Makamba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBumbuli\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.97691600 1485964246.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/250\">Hon.
+        Japhet Ngailonga Hasunga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tVwawa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.60072900 1485929798.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/70\">Hon.
+        Jasson Samson Rweikiza</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBukoba Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.37426700 1486016406.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/405\">Hon.
+        Jenista Joackim Mhagama</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tPeramiho\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.13040400 1485965088.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/549\">Hon.
+        Jerome Dismas Bwanausi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLulindi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.14527500 1486014397.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/315\">Hon.
+        Jesca David Kishoa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.14688600 1485955224.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/136\">Hon.
+        Jitu Vrajlal Soni</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBabati Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.17340700 1455969043.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/44\">Hon.
+        Job Yustino Ndugai</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKongwa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.46953800 1485860519.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/20\">Hon.
+        John John Mnyika</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKibamba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.03188000 1485955556.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/227\">Hon.
+        John Wegesa Heche</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTarime Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.80799500 1485966524.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/446\">Hon.
+        John Peter Kadutu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUlyankulu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91882000 1485965539.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/314\">Hon.
+        Joram Ismael Hongoli</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLupembe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.04471500 1485861449.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/51\">Hon.
+        Joseph Kasheku Musukuma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tGeita\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.88067500 1485954555.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/109\">Hon.
+        Joseph Roman Selasini</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tRombo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.74905800 1485964302.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/239\">Hon.
+        Joseph Osmund Mbilinyi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbeya Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.77979900 1485964899.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/262\">Hon.
+        Joseph Leonard Haule</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMikumi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.53659500 1485965297.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/311\">Hon.
+        Joseph Michael Mkundi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUkerewe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.55761200 1485966038.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/399\">Hon.
+        Joseph Kizito Mhagama</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMadaba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.54666700 1485966536.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/449\">Hon.
+        Joseph George Kakunda</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSikonge\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.08213000 1485965950.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/361\">Hon.
+        Josephat Sinkamba Kandege</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKalambo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.52941800 1486011072.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/120\">Hon.
+        Josephine Johnson Genzabuke</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.61872200 1486010991.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/125\">Hon.
+        Josephine Tabitha Chagulla</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02722400 1485859052.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/9\">Hon.
+        Joshua Samwel  Nassari</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tArumeru-Mashariki\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.03824700 1486015244.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/318\">Hon.
+        Joyce Bitta Sokombi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91573700 1486014793.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/319\">Hon.
+        Joyce John Mukya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.48767800 1486012126.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/130\">Hon.
+        Juliana Daniel Shonza</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.85403400 1485859515.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/14\">Hon.
+        Julius Kalanga Laizer</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMonduli\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.34710500 1485860992.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/36\">Hon.
+        Juma Selemani Nkamia</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChemba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.29578600 1485954703.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/408\">Hon.
+        Juma Hamad Omar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tOle\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.00220600 1485930172.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/486\">Hon.
+        Juma Othman Hija</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTumbatu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.32924700 1485929980.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/504\">Hon.
+        Juma Kombo Hamad</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tWingwi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://www.parliament.go.tz/site/images/img.jpg\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/566\">Hon.
+        Juma Ali Juma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tDimani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45985300 1485966661.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/494\">Hon.
+        Jumaa  Hamidu Aweso</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tPangani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.52629500 1485966165.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/410\">Hon.
+        Jumanne Kibera Kishimba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKahama Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.52850100 1485954344.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/98\">Hon.
+        Kabwe Zuberi Ruyagwa Zitto</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKigoma Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tACT\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.78888500 1485955569.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/199\">Hon.
+        Kangi Alphaxard Lugola</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMwibara\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.07857500 1453645907.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/129\">Hon.
+        Kassim Majaliwa Majaliwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tRuangwa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.64457900 1485954308.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/520\">Hon.
+        Kasuku Samson Bilago</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBuyungu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.56920400 1485965150.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/292\">Hon.
+        Katani Ahmadi Katani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTandahimba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.24828000 1486011390.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/135\">Hon.
+        Kemirembe Rose Julius Lwota</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.90797700 1486011273.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/137\">Hon.
+        Khadija Hassan Aboud</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.03939100 1486011304.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/138\">Hon.
+        Khadija Nassir Ali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.64478100 1486015427.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/366\">Hon.
+        Khadija Salum Ally Al-Qassmy</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.59470800 1485929997.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/476\">Hon.
+        Khalifa Mohammed  Issa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMtambwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.29879800 1485954950.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/488\">Hon.
+        Khalifa Salum  Suleiman</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTunguu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.57484600 1485853387.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/453\">Hon.
+        Khamis Yahya Machano</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChaani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.64153900 1485930205.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/466\">Hon.
+        Khamis  Mtumwa Ali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKiwengwa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.71899000 1485930191.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/479\">Hon.
+        Khamis  Ali  Vuai</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMkwajuni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.80164700 1485930018.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/535\">Hon.
+        Khatib Said Haji</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKonde\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.73140600 1485965241.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/301\">Hon.
+        Kiswaga Boniventura Destery</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMagu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.76829800 1486011330.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/143\">Hon.
+        Kiteto Zawadi Koshuma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.92670700 1486014447.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/321\">Hon.
+        Kunti Yusuph Majala</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.99613300 1485955499.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/201\">Hon.
+        Lameck Okambo Airo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tRorya\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.27398200 1453649829.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/322\">Hon.
+        Lathifah Hassan Chande</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.08064800 1485966448.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/439\">Hon.
+        Lazaro Samuel Nyalandu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSingida Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.39668300 1486011358.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/144\">Hon.
+        Leah Jeremiah Komanya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.26583700 1486016425.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/407\">Hon.
+        Leonidas Tutubert Gama</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSongea Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.76212400 1485860903.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/46\">Hon.
+        Livingstone Joseph Lusinde</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMtera\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.55657500 1485861355.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/49\">Hon.
+        Lolesia Jeremia Maselle Bukwimba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tBusanda\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.56036800 1486014548.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/381\">Hon.
+        Lucia Ursula Michael Mlowe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.38854900 1486011617.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/110\">Hon.
+        Lucy Thomas Mayenga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.46262700 1486014869.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/359\">Hon.
+        Lucy Fidelis Owenya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.40123600 1486014643.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/383\">Hon.
+        Lucy Simon Magereli</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.59958500 1485966285.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/428\">Hon.
+        Luhaga Joelson Mpina</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKisesa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.72605900 1486016060.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/558\">Hon.
+        Machano Othman Said</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHouse of Representatives\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tMember from House of Representatives\n\t\t\t\t
+        \           \t\t\t\t    \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t
+        \   \t<tr class=\"odd\">\n\t\t\t    \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t
+        \   \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.09033600
+        1485965203.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t    \t\t\t</td>\n\t\t\t
+        \   \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/271\">Hon.
+        Maftaha Abdallah Nachuma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMtwara Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.31676800 1485966603.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/440\">Hon.
+        Magdalena Hamis Sakaya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKaliua\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.79629600 1485929114.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/62\">Hon.
+        Mahmoud Hassan Mgimwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMufindi Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.29173000 1486011437.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/146\">Hon.
+        Maida Hamad Abdallah</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.64725200 1485930235.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/506\">Hon.
+        Makame Mashaka Foum</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.87207500 1485964659.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/514\">Hon.
+        Makame Kassim Makame</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMwera\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.39366300 1485965338.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/297\">Hon.
+        Mansoor Shanif Hirani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKwimba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.67822200 1485966615.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/483\">Hon.
+        Margaret Simwanza Sitta</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUrambo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.08695500 1486011212.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/147\">Hon.
+        Maria Ndilla Kangoye</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.85772100 1486012067.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/149\">Hon.
+        Mariamu Ditopile Mzuzuri</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIlala\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.06010200 1486011317.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/150\">Hon.
+        Mariamu Nassoro Kisangi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.71173900 1486012256.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/151\">Hon.
+        Martha Jachi Umbulla</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.48410200 1486011747.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/152\">Hon.
+        Martha Moses Mlata</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.43891700 1485966067.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/403\">Hon.
+        Martin Alexander Mtonda Msuha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbinga Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.68039200 1485955528.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/202\">Hon.
+        Marwa Ryoba Chacha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSerengeti\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.25809500 1486014816.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/326\">Hon.
+        Mary Deo Muro</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.82674400 1485966675.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/491\">Hon.
+        Mary Pius Chatanda</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKorogwe Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.89400000 1486014710.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/332\">Hon.
+        Maryam Salum Msabaha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.52646600 1485966274.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/429\">Hon.
+        Mashimba Mashauri Ndaki</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMaswa Magharibi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.60879500 1485954743.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/481\">Hon.
+        Masoud Abdalla Salim</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMtambile\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.82045300 1485964692.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/485\">Hon.
+        Mattar Ali Salum</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tShaurimoyo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.06522500 1485860554.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/23\">Hon.
+        Maulid Said Abdallah Mtulia</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKinondoni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.72864900 1485964949.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/259\">Hon.
+        Mbaraka Salim Bawazir</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKilosa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.86753800 1485965862.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/340\">Hon.
+        Mbaraka Kitwana Dau</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMafia\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.06690600 1485930043.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/498\">Hon.
+        Mbarouk  Salim  Ali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tWete\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.32668300 1485966749.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/487\">Hon.
+        Mboni Mohamed Mhita</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHandeni Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.79727500 1485866947.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/63\">Hon.
+        Mendard Lutengano Kigola</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMufindi Kusini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44283000 1486015467.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/367\">Hon.
+        Mgeni Jadi Kadika</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.46897200 1486015509.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/368\">Hon.
+        Miza Bakari Haji</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.48679500 1485954789.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/452\">Hon.
+        Mohamed Juma Khatib</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChonga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91103000 1485965889.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/516\">Hon.
+        Mohamed Omary Mchengerwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tRufiji\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45621300 1485930252.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/500\">Hon.
+        Muhammed Amour Muhammed</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBumbwini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.60866600 1486011885.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/154\">Hon.
+        Munde Abdallah Tambwe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.53549800 1486011902.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/156\">Hon
+        Munira Mustafa Khatib</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.30464000 1485966591.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/445\">Hon.
+        Musa Rashid Ntimizi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIgalula\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.92691700 1485966459.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/434\">Hon.
+        Mussa Ramadhani Sima</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSingida Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.41085600 1485964710.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/448\">Hon.
+        Mussa Hassan Mussa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tAmani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.99868000 1485966770.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/501\">Hon.
+        Mussa  Bakari Mbarouk</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTanga Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.11602100 1486011640.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/158\">Hon.
+        Mwanne Ismail Mchemba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTabora Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.51921300 1485964728.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/450\">Hon.
+        Mwantakaje Haji Juma</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBububu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.25923400 1486012031.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/159\">Hon.
+        Mwantum Dau Haji</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.72657600 1485966433.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/433\">Hon.
+        Mwigulu Lameck Nchemba Madelu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIramba Magharibi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.32314800 1485860623.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/29\">Hon.
+        Mwita Mwikwabe Waitara</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUkonga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.14644700 1485954499.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/113\">Hon.
+        Naghenjwa  Livingstone Kaboyoka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tSame Mashariki\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.73747600 1486011085.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/160\">Hon.
+        Najma Murtaza Giga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.48048800 1485955143.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/128\">Hon.
+        Nape Moses Nnauye</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMtama\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.59746200 1485954770.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/508\">Hon.
+        Nassor Suleiman Omar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tZiwani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.33298500 1486011682.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/161\">Hon.
+        Neema William Mgaya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.30238400 1485955645.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/194\">Hon.
+        Nimrod Elirehemah Mkono</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tButiama\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02954500 1485966298.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/426\">Hon.
+        Njalu Daudi Silanga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tItilima\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.54907100 1486012106.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/451\">Hon.
+        Oliver Daniel Semuguruka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.03095600 1485966691.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/542\">Hon.
+        Omar Abdallah Kigoda</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHandeni Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.01776200 1485966706.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/489\">Hon.
+        Omari Mohamed Kigua</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKilindi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.25868500 1485860973.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/34\">Hon.
+        Omary Ahmad Badwel</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBahi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.26084900 1485965000.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/267\">Hon.
+        Omary  Tebweta Mgumba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMorogoro Kusini Mashariki\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.01662200 1485860046.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/12\">Hon.
+        Onesmo Koimerek Nangole</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLongido\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.90789800 1485964451.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/241\">Hon.
+        Oran Manase Njeza</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbeya Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.66813300 1485930072.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/463\">Hon.
+        Othman Omar Haji</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tGando\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.20114700 1485964216.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/252\">Hon.
+        Pascal Yohana Haonga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbozi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02015000 1485955189.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/133\">Hon.
+        Pauline Philipo  Gekul</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBabati Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.48239100 1485954390.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/95\">Hon.
+        Peter Joseph Serukamba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKigoma Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.98971500 1485964927.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/257\">Hon.
+        Peter Ambrose Lijualikali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKilombero\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.91373400 1485964316.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/246\">Hon.
+        Philipo Augustino Mulugo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSongwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.28409800 1485965642.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/317\">Hon.
+        Prof. Adamson Sigalla Norman</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMakete\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.15624700 1485929868.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/77\">Hon.
+        Prof. Anna Kajumulo Tibaijuka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMuleba kusini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.50712000 1486015765.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/529\">Hon.
+        Prof. Joyce Lazaro Ndalichako</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.62014300 1485954511.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/106\">Hon.
+        Prof. Jumanne Abdallah Maghembe</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tMwanga\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.74082400 1486015707.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/525\">Hon.
+        Prof. Makame Mnyaa Mbarawa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNominated\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://www.parliament.go.tz/site/images/img.jpg\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/568\">Hon.
+        Prof. Palamagamba John Aidan Mwaluko Kabudi</a></td>\n\t\t\t    \t\t\t<td>
+        \n\t\t\t\t    \t\t\t\t\t\t\t                \tNominated\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tNominated\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.29193100 1485955659.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/190\">Hon.
+        Prof. Sospeter Mwijarubi Muhongo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t
+        \   \t\t\t\t\t\t\t                \tMusoma Vijijini\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.67712200 1485964966.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/266\">Hon.
+        Prosper Joseph Mbena</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMorogoro Kusini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.92025700 1486015541.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/369\">Hon.
+        Raisa Abdalla Mussa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.56039500 1485954479.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/105\">Hon.
+        Raphael Michael Japhary</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMoshi Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.00288200 1485930092.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/493\">Hon.
+        Rashid Ali Abdallah</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tTumbe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.32060000 1485966796.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/492\">Hon.
+        Rashid Abdallah Shangazi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMlalo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.25502900 1485965118.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/548\">Hon.
+        Rashid Mohamed Chuachua</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMasasi Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.40869100 1485929670.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/56\">Hon.
+        Rev. Peter  Simon Msigwa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIringa Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.75831100 1486014427.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/333\">Hon.
+        Rhoda Edward Kunchela</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKatavi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.33798400 1485954255.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/87\">Hon.
+        Richard Phillip Mbogo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNsimbo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.27791300 1485965312.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/308\">Hon.
+        Richard Mganga Ndassa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSumve\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.13971300 1485965845.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/330\">Hon.
+        Ridhiwani Jakaya Kikwete</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChalinze\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.34806700 1486015213.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/337\">Hon.
+        Risala Said Kabongo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.53583000 1486011167.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/220\">Hon.
+        Ritta Enespher Kabati</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.48184000 1486015495.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/370\">Hon.
+        Riziki Saidi Lulida</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.75784700 1486015525.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/371\">Hon.
+        Riziki Shahari Mngwali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.82011100 1486012235.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/162\">Hon.
+        Rose Cyprian Tweve</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.44299800 1486015257.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/341\">Hon.
+        Rose Kamili Sukum</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.58588000 1486014382.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/385\">Hon.
+        Ruth Hiyob Mollel</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.38010700 1485929855.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/67\">Hon.
+        Rwegasira Mukasa Oscar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBiharamulo Magharibi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.77869400 1485964782.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/502\">Hon.
+        Saada Salum Mkuya</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tWelezo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02492800 1486015281.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/343\">Hon.
+        Sabreena Hamza Sungura</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.89751900 1485930278.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/461\">Hon.
+        Sadifa  Juma  Khamis</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tDonge \n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.70483700 1485860610.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/27\">Hon.
+        Saed Ahmed Kubenea</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUbungo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.81794300 1485964796.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/474\">Hon.
+        Salim Hassan Turky</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMpendae\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.07774200 1486015583.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/372\">Hon.
+        Salma Mohamed Mwassa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45161100 1486014671.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/379\">Hon.
+        Salome Wycliffe Makamba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tShinyanga Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.55887700 1485966331.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/431\">Hon.
+        Salum Khamis Salum</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMeatu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.32944000 1485954963.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/497\">Hon.
+        Salum Mwinyi Rehani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tUzini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.55129200 1485964479.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/244\">Hon.
+        Saul Henry  Amon</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tRungwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.98888600 1486015597.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/374\">Hon.
+        Saumu Heri Sakala</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.47404300 1486015559.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/378\">Hon.
+        Savelina Slivanus Mwijage</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.67568300 1485954224.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/85\">Hon.
+        Sebastian Simon Kapufi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMpanda Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.20508200 1485966513.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/518\">Hon.
+        Seif Khamis Said Gulamali</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tManonga\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02364400 1485954210.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/86\">Hon.
+        Selemani Moshi Kakoso</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMpanda Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.72844700 1485954999.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/122\">Hon.
+        Selemani Said Bungara</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKilwa Kusini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.86534100 1485965821.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/338\">Hon.
+        Selemani Said Jafo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKisarawe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02936900 1485966628.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/443\">Hon.
+        Selemani Jumanne Zedi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBukene\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.41265200 1485966808.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/538\">Hon.
+        Shabani Omari Shekilindi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLushoto\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.36643600 1486011848.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/163\">Hon.
+        Shally Josepha Raymond</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.97688300 1485964810.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/551\">Hon.
+        Shamsi Vuai Nahodha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKijitoupele\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.09616400 1486011027.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/164\">Hon.
+        Sikudhani Yasini Chikambo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.20764100 1486011591.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/166\">Hon.
+        Silafu Jumbe Maufi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.07835700 1485965876.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/335\">Hon.
+        Silvestry Fransis Koka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKibaha Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.53913600 1485966015.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/402\">Hon.
+        Sixtus Raphael Mapunda</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMbinga Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.45932700 1486012143.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/168\">Hon.
+        Sophia Mattayo Simba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.50009600 1486014855.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/345\">Hon.
+        Sophia Hebron Mwakagenda</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tRungwe\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.21134600 1485965266.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/304\">Hon.
+        Stanslaus Shingoma Mabula</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNyamagana\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.65684900 1485966311.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/414\">Hon.
+        Stanslaus Haroon Nyongo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMaswa Mashariki\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.97615400 1486011112.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/170\">Hon.
+        Stella Ikupa Alex</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.17048300 1485966213.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/418\">Hon.
+        Stephen Julius Masele</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tShinyanga Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.81482500 1485966783.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/495\">Hon.
+        Stephen Hillary Ngonyani</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKorogwe Vijijini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.05959400 1486011657.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/172\">Hon.
+        Subira Khamis Mgalu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.99882300 1485965012.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/269\">Hon.
+        Suleiman Ahmed Saddiq</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMvomero\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.79093000 1485966227.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/412\">Hon.
+        Suleiman Masoud Nchambi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKishapu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.15319300 1485964914.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/264\">Hon.
+        Susan Limbweni Kiwanga</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMlimba\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.18203200 1486014587.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/348\">Hon.
+        Susan Anselm Jerome Lyimo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.11799500 1486014727.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/352\">Hon.
+        Susanne Peter Maselle</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.25977500 1486014774.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/349\">Hon.
+        Suzana Chogisasi Mgonukulima</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.21885600 1486012172.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/174\">Hon.
+        Taska Restituta Mbogo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.98798900 1486012194.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/176\">Hon.
+        Tauhida Cassian Galoss Nyimbo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.43774200 1485966390.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/432\">Hon.
+        Tundu Antiphas Mughwai Lissu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSingida Mashariki\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.24643100 1486015313.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/355\">Hon.
+        Tunza Issa Malapo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.58764400 1485954827.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/477\">Hon.
+        Twahir Awesu Mohammed</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMkoani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.34907500 1486012283.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/177\">Hon.
+        Ummy Ally Mwalimu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.02779300 1486015198.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/356\">Hon.
+        Upendo Furaha Peneza</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.84681500 1485964570.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/454\">Hon.
+        Ussi Salum  Pondeza</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChumbuni\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.12564400 1485955159.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/123\">Hon.
+        Vedasto Edgar Ngombale Mwiru</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKilwa Kaskazini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.03671000 1485955587.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/197\">Hon.
+        Vedastus Mathayo Manyinyi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tMusoma Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.23140400 1485929690.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/61\">Hon.
+        Venance Methusalah Mwamoto</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKilolo\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.22661100 1486011196.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/397\">Hon.
+        Vicky Paschal Kamata</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.31846700 1485964398.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/237\">Hon.
+        Victor Kilasile Mwambalaswa</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLupa\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.22782000 1486016081.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/560\">Hon.
+        Wanu Hafidh Ameir</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tHouse of Representatives\n\t\t\t\t                \t\t\t\t
+        \           </td>\n\t\t\t            \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tMember from House of Representatives\n\t\t\t\t
+        \           \t\t\t\t    \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t
+        \   \t<tr class=\"odd\">\n\t\t\t    \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t
+        \   \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.74792100
+        1485929825.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t    \t\t\t</td>\n\t\t\t
+        \   \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/69\">Hon.
+        Wilfred Muganyizi Lwakatare</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tBukoba Mjini\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.26709200 1485858862.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/15\">Hon.
+        William Tate Olenasha</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNgorongoro\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.58934500 1485867050.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/57\">Hon.
+        William Vangimembe Lukuvi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tIsmani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.52340800 1485965326.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/307\">Hon.
+        William Mganga Ngeleja</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSengerema\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.41322300 1485859332.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/10\">Hon.
+        Willy Qulwi Qambalo</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tKaratu\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.32657500 1485966404.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/435\">Hon.
+        Yahaya Omary Massare</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tManyoni Magharibi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.76736300 1486015340.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/358\">Hon.
+        Yosepher Ferdinand Komba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.38949400 1485954716.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/455\">Hon.
+        Yussuf Kaiza Makame</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChake Chake\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.87691900 1485954861.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/457\">Hon.
+        Yussuf Salim Hussein</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tChambani\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.12312800 1485930295.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/480\">Hon.
+        Yussuf Haji Khamis</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tNungwi\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.03060400 1486011238.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/181\">Hon.
+        Zainab Athman Katimba</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.17635800 1486011994.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/185\">Hon.
+        Zainabu Nuhu Mwamwindi</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.89109600 1486015361.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/360\">Hon.
+        Zainabu Mussa Bakar</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.12688100 1486012309.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/186\">Hon.
+        Zaynab Matitu Vulu</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCCM\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.15857900 1486015377.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/362\">Hon.
+        Zubeda Hassan Sakuru</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tSpecial Seats\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCHADEMA\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tSpecial Seats\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t\t    \t<tr class=\"odd\">\n\t\t\t
+        \   \t\t\t<td>\n\t\t\t    \t\t\t\t<div class=\"mps_pic\">\t\n\t\t\t\t    \t\t\t\t\t\t\t\t\t\t\t\t\t\t<img
+        src=\"http://parliament.go.tz/polis/uploads/members/0.04490800 1485955053.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t
+        \   \t\t\t</td>\n\t\t\t    \t\t\t<td><a href=\"http://www.parliament.go.tz/administrations/117\">Hon.
+        Zuberi Mohamedi Kuchauka</a></td>\n\t\t\t    \t\t\t<td> \n\t\t\t\t    \t\t\t\t\t\t\t
+        \               \tLiwale\n\t\t\t\t                \t\t\t\t            </td>\n\t\t\t
+        \           \t<td>\n\t\t\t            \t\t\t\t                \t\t\tCUF\n\t\t
+        \               \t\t\t\t\t            \t</td>\n\t\t\t    \t\t\t<td width=\"20%\">\n\t\t\t
+        \   \t\t\t\t\t\t\t\t                \tConstituent Member\n\t\t\t\t            \t\t\t\t
+        \   \t\t\t</td>\n\t\t\t        </tr>\n\t\t\t    \t\t    </tbody>\n\t\t</table>\n\t\n\t</div>\n\n\t\t\n\t</div>\n\n\t<div
+        class=\"in_right\">\n\t\t<div class=\"slide\">\n\t\t\t\t<div class=\"speaker\">\n\t\t\t\t\t\t\t\t\t\t\t<div
+        class=\"pro_pic\"><img src=\"http://www.parliament.go.tz/uploads/administrations/thumb/1456133578-ndugai1.jpg\"></div>\n\t\t\t\t\t\t<div
+        class=\"pro_info\">\n\t\t\t\t\t\t\t<p class=\"name\">Hon. Job Y. Ndugai</p>\n\t\t\t\t\t\t\t<p
+        class=\"place\">Speaker of the National Assembly</p>\n\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/legistrative_role/29\"><i class=\"fa fa-angle-double-right
+        right\"></i>Legislative Role</a></p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/profile/29\"><i
+        class=\"fa fa-angle-double-right right\"></i>Profile</a></p>\n\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/administration-questions/29\"><i class=\"fa
+        fa-angle-double-right right\"></i>Ask the Speaker / Comments</a></p>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t</div>\n\n\t\t\t\t<div
+        class=\"speaker\">\n\t\t\t\t\t\t\t\t\t\t\t<div class=\"pro_pic\"><img src=\"http://www.parliament.go.tz/uploads/administrations/thumb/1449740445-KB
+        3.jpg\"></div>\n\t\t\t\t\t\t<div class=\"pro_info\">\n\t\t\t\t\t\t\t<p class=\"name\">Dr.
+        Thomas D. Kashililah</p>\n\t\t\t\t\t\t\t<p class=\"place\">Clerk of the National
+        Assembly</p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/legistrative_role/2\"><i
+        class=\"fa fa-angle-double-right right\"></i>Legislative Role</a></p>\n\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/profile/2\"><i class=\"fa fa-angle-double-right
+        right\"></i>Profile</a></p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/administration-questions/2\"><i
+        class=\"fa fa-angle-double-right right\"></i>Ask the Clerk / Comments</a></p>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t</div>\n\t\t</div>\n\t\t<div
+        class=\"polis\">\t\t\t\t\t\n\t\t\t<div class=\"tr_poli_in\"><a href=\"http://parliament.go.tz/polis\"
+        target=\"blank\"><img src=\"http://www.parliament.go.tz/site/images/polisin.png\"></a></div>\n\t\t\t<div
+        class=\"tr_mail_in\"><a href=\"http://mail.bunge.go.tz\" target=\"blank\"><img
+        src=\"http://www.parliament.go.tz/site/images/webin.png\"></a>\t</div>\t\t\t\t\n\t\t</div>\n\t\t<div
+        class=\"mps mps_in\">\n\t\t\t<h4>Member of the Parliament</h4>\n\t\t\t<div
+        class=\"profs\" id=\"slideshow\">\n\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t<div>\n\t\t\t\t\t\t<div
+        class=\"pro_pic\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.86955000
+        1485861011.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t\t\t\t<div class=\"pro_info\">\n\t\t\t\t\t\t\t<p
+        class=\"name\">Hon. Antony Peter Mavunde</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p
+        class=\"place\">Dodoma mjini (CCM)</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/primary_questions/40\"><i class=\"fa fa-angle-double-right
+        right\"></i>Questions (0)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/supplementary_questions/40\"><i
+        class=\"fa fa-angle-double-right right\"></i>Supplementary Questions (0)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/contributions/40\"><i class=\"fa fa-angle-double-right
+        right\"></i>Contributions (1)</a></p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/administrations/40\"><i
+        class=\"fa fa-angle-double-right right\"></i>Profile</a></p>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t<div>\n\t\t\t\t\t\t<div
+        class=\"pro_pic\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.85017700
+        1486011773.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t\t\t\t<div class=\"pro_info\">\n\t\t\t\t\t\t\t<p
+        class=\"name\">Hon. Amina Saleh Athuman Mollel</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p
+        class=\"place\">Special Seats (CCM)</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/primary_questions/214\"><i class=\"fa fa-angle-double-right
+        right\"></i>Questions (2)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/supplementary_questions/214\"><i
+        class=\"fa fa-angle-double-right right\"></i>Supplementary Questions (11)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/contributions/214\"><i class=\"fa fa-angle-double-right
+        right\"></i>Contributions (12)</a></p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/administrations/214\"><i
+        class=\"fa fa-angle-double-right right\"></i>Profile</a></p>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t<div>\n\t\t\t\t\t\t<div
+        class=\"pro_pic\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.11799500
+        1486014727.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t\t\t\t<div class=\"pro_info\">\n\t\t\t\t\t\t\t<p
+        class=\"name\">Hon. Susanne Peter Maselle</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p
+        class=\"place\">Special Seats (CHADEMA)</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/primary_questions/352\"><i class=\"fa fa-angle-double-right
+        right\"></i>Questions (2)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/supplementary_questions/352\"><i
+        class=\"fa fa-angle-double-right right\"></i>Supplementary Questions (2)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/contributions/352\"><i class=\"fa fa-angle-double-right
+        right\"></i>Contributions (1)</a></p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/administrations/352\"><i
+        class=\"fa fa-angle-double-right right\"></i>Profile</a></p>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t<div>\n\t\t\t\t\t\t<div
+        class=\"pro_pic\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://parliament.go.tz/polis/uploads/members/0.07774200
+        1486015583.png\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t\t\t\t<div class=\"pro_info\">\n\t\t\t\t\t\t\t<p
+        class=\"name\">Hon. Salma Mohamed Mwassa</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p
+        class=\"place\">Special Seats (CUF)</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/primary_questions/372\"><i class=\"fa fa-angle-double-right
+        right\"></i>Questions (3)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/supplementary_questions/372\"><i
+        class=\"fa fa-angle-double-right right\"></i>Supplementary Questions (3)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/contributions/372\"><i class=\"fa fa-angle-double-right
+        right\"></i>Contributions (7)</a></p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/administrations/372\"><i
+        class=\"fa fa-angle-double-right right\"></i>Profile</a></p>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t<div>\n\t\t\t\t\t\t<div
+        class=\"pro_pic\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<img src=\"http://www.parliament.go.tz/site/images/img.jpg\">\n\t\t\t\t\t\t\t\t\t\t\t\t\t</div>\n\t\t\t\t\t\t<div
+        class=\"pro_info\">\n\t\t\t\t\t\t\t<p class=\"name\">Hon. Juma Ali Juma</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p
+        class=\"place\">Dimani (CCM)</p>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/primary_questions/566\"><i
+        class=\"fa fa-angle-double-right right\"></i>Questions (0)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/supplementary_questions/566\"><i class=\"fa
+        fa-angle-double-right right\"></i>Supplementary Questions (0)</a></p>\n\t\t\t\t\t\t\t\t\t\t\t<p><a
+        href=\"http://www.parliament.go.tz/contributions/566\"><i class=\"fa fa-angle-double-right
+        right\"></i>Contributions (0)</a></p>\n\t\t\t\t\t\t\t<p><a href=\"http://www.parliament.go.tz/administrations/566\"><i
+        class=\"fa fa-angle-double-right right\"></i>Profile</a></p>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t\t</div>\t\n\t\t</div>\n\t\t\t\t\t<p
+        id=\"all\"><a href=\"http://www.parliament.go.tz/mps-list\">View All MP's</a></p>\n\t\t\t</div></div>\n\n\n\n<div
+        class=\"footer\">\n    <div class=\"foot_wrap\">\n      <ul class=\"contacts\">\n
+        \       <h3>Our Parliament</h3>\n                      <li><a href=\"http://www.parliament.go.tz/pages/history\"><i
+        class=\"fa fa-circle-o right\"></i>Who we are</a></li>\n                      <li><a
+        href=\"http://www.parliament.go.tz/pages/functions\"><i class=\"fa fa-circle-o
+        right\"></i>What Parliament does</a></li>\n                      <li><a href=\"http://www.parliament.go.tz/pages/structure\"><i
+        class=\"fa fa-circle-o right\"></i>Parliament Structure</a></li>\n                </ul>\n
+        \     <ul class=\"contacts\">\n        <h3>Document</h3>\n                  <li><a
+        href=\"http://www.parliament.go.tz/acts-list\"><i class=\"fa fa-circle-o right\"></i>Acts</a></li>\n
+        \                 <li><a href=\"http://www.parliament.go.tz/bills-list\"><i
+        class=\"fa fa-circle-o right\"></i>Bills</a></li>\n                  <li><a
+        href=\"http://www.parliament.go.tz/budget-list\"><i class=\"fa fa-circle-o
+        right\"></i>Budget Speeches</a></li>\n                  <li><a href=\"http://www.parliament.go.tz/hansards-list\"><i
+        class=\"fa fa-circle-o right\"></i>Hansard</a></li>\n              </ul>\n
+        \     <ul class=\"contacts\">\n        <h3>Get Involved</h3>\n        <li><a
+        href=\"https://twitter.com/bunge_tz\" target=\"_blank\"><i class=\"fa fa-circle-o
+        right\"></i>Twitter</a></li>\n        <li><a href=\"https://www.facebook.com/bungetz1/?ref=aymt_homepage_panel\"
+        target=\"_blank\"><i class=\"fa fa-circle-o right\"></i>Facebook</a></li>\n
+        \       <li><a href=\"https://www.instagram.com/bunge_tanzania\" target=\"_blank\"><i
+        class=\"fa fa-circle-o right\"></i>Instagram</a></li>\n        <li><a href=\"https://bungetz.blogspot.com\"
+        target=\"_blank\"><i class=\"fa fa-circle-o right\"></i>Blog</a></li>\n        <li><a
+        href=\"http://www.parliament.go.tz/application\" ><i class=\"fa fa-circle-o
+        right\"></i>Visit Us</a></li>\n        <li><a href=\"http://www.parliament.go.tz/contact\"><i
+        class=\"fa fa-circle-o right\"></i>Contact Us</a></li>\n      </ul>\n      <div
+        class=\"newsletter\">\n        <h3>Sign-up for Bunge Newsletter</h3>\n        <p>Subscribe
+        and receive monthly updates via email.</p>\n        <div id=\"success_subscription\">\n
+        \           <a href=\"http://www.parliament.go.tz/subscribers/create\"> Subscribe
+        <i class=\"fa fa-play right\"></i></a>\n            <p><a href=\"http://www.parliament.go.tz/unsubscribe\">
+        Unsubscribe <i class=\"fa fa-play right\"></i></a></p>\n            <span
+        class=\"footnote\"> Copyright &copy; 2015. Bunge Website. All rights reserved</span>\n
+        \       </div>\n      </div>\n  <!-- /#footer -->\n  \n<script src=\"http://www.parliament.go.tz/site/js/jquery-ui.js\"
+        type=\"text/javascript\"></script>\n<script src=\"http://www.parliament.go.tz/site/js/bootstrap-datepicker.min.js\"
+        type=\"text/javascript\"></script>\n<script src=\"http://www.parliament.go.tz/site/js/bootstrap-multiselect.js\"
+        type=\"text/javascript\"></script>\n<script type=\"text/javascript\">\n    $(document).ready(function()
+        {  \n      $('.multiselect').multiselect();\n      $('.datepicker').datepicker({\n
+        \     format: 'yyyy-mm-dd',\n      autoclose: 'true'\n      // startDate:
+        '-3d'\n      });  \n    });\n</script>\n\n</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 20 Feb 2017 14:24:32 GMT
+recorded_with: VCR 3.0.3

--- a/test/member_row_test.rb
+++ b/test/member_row_test.rb
@@ -6,14 +6,14 @@ describe 'MemberRow' do
   around { |test| VCR.use_cassette(url.split('/').last, &test) }
 
   subject do
-    MembersPage.new(response: Scraped::Request.new(url: url).response)
+    MembersPage.new(response: Scraped::Request.new(url: url).response).member_rows.first.to_h
   end
 
-  describe 'member row data' do
-    let(:url) { 'http://www.parliament.go.tz/mps-list' }
+  let(:url) { 'http://www.parliament.go.tz/mps-list' }
 
+  describe 'member row data' do
     it 'should have the expected data' do
-      subject.member_rows.first.to_h.must_equal(
+      subject.must_equal(
         id:          '458',
         photo:       'http://parliament.go.tz/polis/uploads/members/0.57945900%201485964592.png',
         name:        'Abbas Ali Mwinyi',
@@ -22,6 +22,12 @@ describe 'MemberRow' do
         member_type: 'Constituent Member',
         source:      'http://www.parliament.go.tz/administrations/458'
       )
+    end
+  end
+
+  describe 'console output' do
+    it 'should not warn of URI.escape obsolescence' do
+      proc { puts subject[:photo] }.must_be_silent
     end
   end
 end

--- a/test/member_row_test.rb
+++ b/test/member_row_test.rb
@@ -27,7 +27,7 @@ describe 'MemberRow' do
 
   describe 'console output' do
     it 'should not warn of URI.escape obsolescence' do
-      proc { puts subject[:photo] }.must_be_silent
+      proc { subject[:photo] }.must_be_silent
     end
   end
 end

--- a/test/member_row_test.rb
+++ b/test/member_row_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require_relative './test_helper'
+require_relative '../lib/members_page.rb'
+
+describe 'MemberRow' do
+  around { |test| VCR.use_cassette(url.split('/').last, &test) }
+
+  subject do
+    MembersPage.new(response: Scraped::Request.new(url: url).response)
+  end
+
+  describe 'member row data' do
+    let(:url) { 'http://www.parliament.go.tz/mps-list' }
+
+    it 'should have the expected data' do
+      subject.member_rows.first.to_h.must_equal(
+        id:          '458',
+        photo:       'http://parliament.go.tz/polis/uploads/members/0.57945900%201485964592.png',
+        name:        'Abbas Ali Mwinyi',
+        area:        'Fuoni',
+        party:       'CCM',
+        member_type: 'Constituent Member',
+        source:      'http://www.parliament.go.tz/administrations/458'
+      )
+    end
+  end
+end


### PR DESCRIPTION
URI.encode has been obsoleted. Since it was used here to handle
the whitespace, it has been substituted with a gsub.

Note: I am unable to find a direct equivalent in the standard library.
CGI.escape and URI.encode_www_form_component do not return the
same value.

```
str = "https://example url.com"

URI.encode str
=> "https://example%20url.com"

CGI.escape str
=> "https%3A%2F%2Fexample+url.com"

URI.encode_www_form_component str
=> "https%3A%2F%2Fexample+url.com"
```