### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -31,5 +31,5 @@ def scrape_term(url, term)
 end
 
 url = 'http://www.parliament.go.tz/mps-list'
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 scrape_term(url, 5)


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite, we need to create a new table to ensure the db reflects the change.

Part of: https://github.com/everypolitician/everypolitician/issues/593